### PR TITLE
Use env var for Gemini API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# Podcast-Bundle
+# Podcast Bundle
+
+This project is a simple React application built with Vite. It contains an AI powered helper that uses Google's Gemini API to recommend the best podcast production plan.
+
+## Development
+
+1. Install dependencies
+   ```bash
+   npm install
+   ```
+2. Create a `.env` file in the project root (or set environment variables in your shell) and define the Gemini API key:
+   ```bash
+   VITE_GEMINI_API_KEY=your-api-key-here
+   ```
+3. Start the development server
+   ```bash
+   npm run dev
+   ```
+4. Build for production
+   ```bash
+   npm run build
+   ```
+
+The application reads `VITE_GEMINI_API_KEY` using `import.meta.env` at runtime. The Vite configuration exposes variables prefixed with `VITE_` during the build, so the value will be inlined when the app is bundled.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -119,7 +119,7 @@ const AIAdvisorSlide = () => {
             Please provide a clear recommendation and a brief justification. Start with "Based on your needs, I'd recommend the..."
         `;
 
-        const apiKey = ""; // API key will be injected by the environment
+        const apiKey = import.meta.env.VITE_GEMINI_API_KEY; // API key provided via Vite environment
         const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-preview-05-20:generateContent?key=${apiKey}`;
 
         try {

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,4 +3,6 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
+  // Explicitly allow access to variables starting with VITE_
+  envPrefix: 'VITE_',
 })


### PR DESCRIPTION
## Summary
- inject Gemini API key from `import.meta.env.VITE_GEMINI_API_KEY`
- configure Vite to expose `VITE_` variables
- document setup and API key usage

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688947398d1c832b869b732875d47f7a